### PR TITLE
fix: cannot read property 'error' of undefined

### DIFF
--- a/stacktracey.js
+++ b/stacktracey.js
@@ -160,7 +160,11 @@ class StackTracey extends Array {
         } else {
 
             let resolved = getSource (loc.file || '').resolve (loc)
-            
+
+            if (!resolved.sourceFile) {
+                return loc
+            }
+
             if (!resolved.sourceFile.error) {
                 resolved.file = nixSlashes (resolved.sourceFile.path)
                 resolved = StackTracey.extractEntryMetadata (resolved)


### PR DESCRIPTION
I had this error in pnpm. I am not sure how to reproduce it but this change fixes the error